### PR TITLE
Fix: FLE Settlement Report

### DIFF
--- a/slcm/api/fix_reports.py
+++ b/slcm/api/fix_reports.py
@@ -1,0 +1,71 @@
+"""
+One-time utility to fix reports that were accidentally set to prepared_report=1
+in the database, which causes the "This is a background report" error and the
+TypeError: Cannot read properties of null (reading 'report_end_time') JS crash.
+
+Run on the cloud server after deployment:
+    bench execute slcm.api.fix_reports.reset_prepared_report_flags
+
+Or call via API (System Manager only):
+    POST /api/method/slcm.api.fix_reports.reset_prepared_report_flags
+"""
+
+import frappe
+
+
+# Reports that must NEVER run as background/prepared reports
+SCRIPT_REPORTS_TO_FIX = [
+    "FLE Razorpay Settlement Report",
+    "FLE Settlement Report",
+]
+
+
+@frappe.whitelist()
+def reset_prepared_report_flags():
+    """
+    Resets prepared_report=0 for all live-API Script Reports in SLCM.
+    Safe to run multiple times. Requires System Manager role.
+    """
+    if not frappe.has_permission("Report", "write"):
+        frappe.throw("You do not have permission to run this.", frappe.PermissionError)
+
+    fixed = []
+
+    for report_name in SCRIPT_REPORTS_TO_FIX:
+        if not frappe.db.exists("Report", report_name):
+            frappe.logger().warning(f"fix_reports: Report '{report_name}' not found in DB — skipping.")
+            continue
+
+        current = frappe.db.get_value("Report", report_name, "prepared_report")
+        if current:
+            frappe.db.set_value("Report", report_name, {
+                "prepared_report": 0,
+                "timeout": 300,
+            })
+            # Also delete any stale Prepared Report documents that cause the JS crash
+            stale = frappe.get_all(
+                "Prepared Report",
+                filters={"report_name": report_name},
+                pluck="name",
+            )
+            for pr in stale:
+                frappe.delete_doc("Prepared Report", pr, force=True)
+                frappe.logger().info(f"fix_reports: Deleted stale Prepared Report '{pr}'")
+
+            fixed.append(report_name)
+            frappe.logger().info(
+                f"fix_reports: Reset prepared_report=0 for '{report_name}'. "
+                f"Deleted {len(stale)} stale Prepared Report doc(s)."
+            )
+        else:
+            frappe.logger().info(f"fix_reports: '{report_name}' already has prepared_report=0 — no change needed.")
+
+    frappe.db.commit()
+
+    if fixed:
+        msg = f"Fixed {len(fixed)} report(s): {', '.join(fixed)}. Please hard-refresh your browser (Ctrl+Shift+R)."
+    else:
+        msg = "All reports were already correctly configured. No changes made."
+
+    frappe.logger().info(f"fix_reports: {msg}")
+    return msg

--- a/slcm/api/sync_settlements.py
+++ b/slcm/api/sync_settlements.py
@@ -1,78 +1,349 @@
+"""
+Manual settlement sync — backfills settlement data into FLE Payment Log.
+
+Call via bench console:
+    frappe.call("slcm.api.sync_settlements.run_sync")
+
+Or via API (System Manager only):
+    POST /api/method/slcm.api.sync_settlements.run_sync
+"""
+
+import datetime
+
 import frappe
 import requests
-import datetime
-from slcm.api.razorpay_webhook import _fetch_settlement_recon
+
+
+RAZORPAY_BASE   = "https://api.razorpay.com/v1"
+PAGE_SIZE       = 100   # max for /v1/settlements
+RECON_PAGE_SIZE = 500   # max per page for /v1/settlements/{id}/recon/combined
+
+
+@frappe.whitelist()
+def diagnose_missing_matches():
+    """
+    Diagnoses why Contact Name is blank in the settlement report.
+
+    Uses /v1/settlements/recon/combined (same API as the report) to collect
+    all settled payment IDs, then cross-checks against FLE Payment Log.
+    """
+    import json
+    from datetime import datetime, timezone
+
+    settings   = frappe.get_single("Razorpay Settings")
+    api_key    = settings.api_key
+    api_secret = settings.get_password("api_secret")
+    if not api_key or not api_secret:
+        frappe.throw("API credentials are missing in Razorpay Settings.")
+
+    auth = (api_key, api_secret)
+
+    # Step 1: fetch settlement list
+    settlements = _fetch_all_settlements(auth)
+    if not settlements:
+        return {"error": "No settlements returned from Razorpay. Check API credentials."}
+
+    setl_by_id = {s["id"]: s for s in settlements if s.get("id")}
+
+    # Step 2: collect all payment IDs from recon/combined (same logic as the report)
+    # Determine year-months from settlements
+    year_months = set()
+    for s in settlements:
+        ts = s.get("created_at")
+        if ts:
+            try:
+                dt = datetime.fromtimestamp(int(ts), tz=timezone.utc)
+                year_months.add((dt.year, dt.month))
+            except Exception:
+                pass
+    year_months = sorted(year_months)
+
+    target_ids      = set(setl_by_id.keys())
+    razorpay_pids   = set()   # pay_xxx IDs from recon
+    recon_available = False
+
+    for year, month in year_months:
+        skip = 0
+        while True:
+            resp = requests.get(
+                "https://api.razorpay.com/v1/settlements/recon/combined",
+                auth=auth,
+                params={"year": year, "month": month, "count": 1000, "skip": skip},
+                timeout=60,
+            )
+            if resp.status_code == 404:
+                break   # recon not enabled
+            if not resp.ok:
+                break
+
+            recon_available = True
+            items = resp.json().get("items", [])
+            for item in items:
+                if item.get("settlement_id") not in target_ids:
+                    continue
+                pid = item.get("entity_id") or item.get("payment_id") or ""
+                if pid:
+                    razorpay_pids.add(pid)
+
+            if len(items) < 1000:
+                break
+            skip += 1000
+
+    # Step 3: collect payment IDs from FLE Payment Log
+    fle_rows = frappe.db.sql(
+        """
+        SELECT
+            name,
+            transaction_id,
+            full_name,
+            gateway_response
+        FROM `tabFLE Payment Log`
+        """,
+        as_dict=True,
+    )
+
+    # Build FLE map — also try extracting pay_xxx from gateway_response
+    # when transaction_id is NULL (Integration Request data format)
+    fle_tid_map  = {}   # pay_xxx → full_name
+    null_tid_rows = 0
+
+    for r in fle_rows:
+        tid = (r.transaction_id or "").strip()
+        if not tid:
+            # Try extracting from gateway_response JSON
+            try:
+                gw   = json.loads(r.gateway_response or "{}")
+                tid  = (
+                    gw.get("razorpay_payment_id")
+                    or gw.get("payload", {}).get("payment", {}).get("entity", {}).get("id")
+                    or ""
+                )
+            except Exception:
+                pass
+        if tid:
+            fle_tid_map[tid] = r.full_name or ""
+        else:
+            null_tid_rows += 1
+
+    # Step 4: cross-check
+    matched    = [pid for pid in razorpay_pids if pid in fle_tid_map]
+    unmatched  = [pid for pid in razorpay_pids if pid not in fle_tid_map]
+    blank_name = [pid for pid in matched if not fle_tid_map.get(pid)]
+
+    result = {
+        "recon_api_available":           recon_available,
+        "total_settlements":             len(settlements),
+        "total_razorpay_payment_ids":    len(razorpay_pids),
+        "total_fle_payment_log_records": len(fle_rows),
+        "fle_rows_with_null_tid":        null_tid_rows,
+        "matched_with_fle_log":          len(matched),
+        "unmatched_no_fle_log":          len(unmatched),
+        "matched_but_blank_name":        len(blank_name),
+        "sample_unmatched_ids":          unmatched[:10],
+        "sample_blank_name_ids":         blank_name[:10],
+    }
+
+    frappe.logger().info(f"diagnose_missing_matches: {result}")
+    return result
+
+
+@frappe.whitelist()
+def backfill_contact_names():
+    """
+    One-time backfill: copies candidate_name and email_address from the linked
+    'Foundations for a Legal Education' document into any FLE Payment Log rows
+    where full_name is blank.
+
+    Run after deployment to fix all existing records:
+        bench execute slcm.api.sync_settlements.backfill_contact_names
+    Or via API button in the report.
+    """
+    rows = frappe.db.sql(
+        """
+        SELECT fpl.name, fpl.reference_no
+        FROM `tabFLE Payment Log` fpl
+        WHERE (fpl.full_name IS NULL OR fpl.full_name = '')
+          AND fpl.reference_no IS NOT NULL
+          AND fpl.reference_no != ''
+        """,
+        as_dict=True,
+    )
+
+    updated = 0
+    for row in rows:
+        fle = frappe.db.get_value(
+            "Foundations for a Legal Education",
+            row.reference_no,
+            ["candidate_name", "email_address"],
+            as_dict=True,
+        )
+        if not fle:
+            continue
+        frappe.db.set_value("FLE Payment Log", row.name, {
+            "full_name": fle.candidate_name or "",
+            "email":     fle.email_address  or "",
+        }, update_modified=False)
+        updated += 1
+
+    frappe.db.commit()
+    msg = f"Backfilled contact name/email for {updated} FLE Payment Log records."
+    frappe.logger().info(msg)
+    return msg
+
 
 @frappe.whitelist()
 def run_sync():
-	"""
-	Run this once to sync all past settlements from Razorpay.
-	You can call this via API: 
-	http://your-site/api/method/slcm.api.sync_settlements.run_sync
-	Or run in bench console:
-	frappe.get_doc("slcm.api.sync_settlements").run_sync()
-	"""
-	settings = frappe.get_single("Razorpay Settings")
-	api_key = settings.api_key
-	api_secret = settings.get_password("api_secret")
+    settings   = frappe.get_single("Razorpay Settings")
+    api_key    = settings.api_key
+    api_secret = settings.get_password("api_secret")
 
-	if not api_key or not api_secret:
-		return "API Keys are missing in Razorpay Settings."
+    if not api_key or not api_secret:
+        frappe.throw("API credentials are missing in Razorpay Settings.")
 
-	# Fetch recent settlements (max 100 for example, you can handle pagination if you have more)
-	url = "https://api.razorpay.com/v1/settlements"
-	resp = requests.get(url, auth=(api_key, api_secret), params={"count": 100})
-	
-	if resp.status_code != 200:
-		return f"Error fetching settlements: {resp.text}"
+    auth = (api_key, api_secret)
 
-	settlements = resp.json().get("items", [])
-	total_updated = 0
+    # Fetch all settlements (paginated)
+    settlements     = _fetch_all_settlements(auth)
+    total_updated   = 0
+    total_processed = 0
 
-	for st in settlements:
-		settlement_id = st.get("id")
-		utr = st.get("utr") or ""
-		status = st.get("status") or "processed"
-		created_at = st.get("created_at")
-		
-		settlement_date = None
-		if created_at:
-			try:
-				settlement_date = datetime.datetime.utcfromtimestamp(int(created_at)).date()
-			except Exception:
-				pass
-		
-		recon_items = _fetch_settlement_recon(settlement_id, api_key, api_secret)
-		updated = 0
+    for st in settlements:
+        settlement_id = st.get("id")
+        if not settlement_id:
+            continue
 
-		for item in recon_items:
-			if item.get("type") not in ("payment", None):
-				continue
+        utr    = st.get("utr") or ""
+        status = st.get("status") or "processed"
 
-			rzp_payment_id = item.get("razorpay_payment_id") or item.get("entity_id") or ""
-			if not rzp_payment_id:
-				continue
+        settlement_date = None
+        created_at      = st.get("created_at")
+        if created_at:
+            try:
+                settlement_date = datetime.datetime.utcfromtimestamp(int(created_at)).date()
+            except Exception:
+                pass
 
-			log_name = frappe.db.get_value("FLE Payment Log", {"transaction_id": rzp_payment_id}, "name")
-			if not log_name:
-				continue
+        recon_items = _fetch_settlement_recon(settlement_id, auth)
+        updated     = 0
 
-			fee_paise = item.get("fee") or 0
-			tax_paise = item.get("tax") or 0
-			credit_paise = item.get("credit") or item.get("amount") or 0
+        for item in recon_items:
+            # Razorpay recon/combined uses entity_type; skip refunds
+            entity_type = item.get("type") or item.get("entity_type") or ""
+            if entity_type and entity_type not in ("payment", ""):
+                continue
 
-			frappe.db.set_value("FLE Payment Log", log_name, {
-				"settlement_id": settlement_id,
-				"settlement_utr": utr,
-				"settlement_date": settlement_date,
-				"settlement_status": status,
-				"gateway_fees": round(fee_paise / 100, 2),
-				"gateway_tax": round(tax_paise / 100, 2),
-				"net_settled": round(credit_paise / 100, 2),
-			})
-			updated += 1
-		
-		frappe.logger().info(f"Sync: Settlement {settlement_id} updated {updated} records.")
-		total_updated += updated
+            # Razorpay uses different field names across API versions
+            rzp_payment_id = (
+                item.get("razorpay_payment_id")
+                or item.get("entity_id")
+                or item.get("payment_id")
+                or ""
+            )
+            if not rzp_payment_id:
+                continue
 
-	return f"Successfully synchronized {len(settlements)} settlements and updated {total_updated} FLE Payment Log records."
+            log_name = frappe.db.get_value(
+                "FLE Payment Log",
+                {"transaction_id": rzp_payment_id},
+                "name",
+            )
+            if not log_name:
+                continue
+
+            fee_paise    = item.get("fee") or item.get("fees") or 0
+            tax_paise    = item.get("tax") or 0
+            credit_paise = item.get("credit") or item.get("amount") or 0
+
+            frappe.db.set_value("FLE Payment Log", log_name, {
+                "settlement_id":     settlement_id,
+                "settlement_utr":    utr,
+                "settlement_date":   settlement_date,
+                "settlement_status": status,
+                "gateway_fees":      round(fee_paise / 100, 2),
+                "gateway_tax":       round(tax_paise / 100, 2),
+                "net_settled":       round(credit_paise / 100, 2),
+            })
+            updated += 1
+
+        frappe.logger().info(
+            f"Sync: Settlement {settlement_id} (UTR: {utr}) — updated {updated} FLE Payment Log records."
+        )
+        total_updated   += updated
+        total_processed += 1
+
+    frappe.db.commit()
+
+    msg = (
+        f"Sync complete. Processed {total_processed} settlements, "
+        f"updated {total_updated} FLE Payment Log records."
+    )
+    frappe.logger().info(msg)
+    return msg
+
+
+def _fetch_all_settlements(auth):
+    """Paginate through /v1/settlements and return all items."""
+    settlements = []
+    skip        = 0
+
+    while True:
+        resp = requests.get(
+            f"{RAZORPAY_BASE}/settlements",
+            auth=auth,
+            params={"count": PAGE_SIZE, "skip": skip},
+            timeout=30,
+        )
+        if not resp.ok:
+            frappe.log_error(
+                f"Razorpay /settlements error {resp.status_code}: {resp.text[:300]}",
+                "sync_settlements",
+            )
+            frappe.throw(
+                f"Razorpay API error {resp.status_code}: {resp.text[:300]}"
+            )
+
+        items = resp.json().get("items", [])
+        settlements.extend(items)
+
+        if len(items) < PAGE_SIZE:
+            break
+        skip += PAGE_SIZE
+
+    return settlements
+
+
+def _fetch_settlement_recon(settlement_id, auth):
+    """Fetch all recon items for one settlement (paginated)."""
+    items = []
+    skip  = 0
+
+    while True:
+        resp = requests.get(
+            f"{RAZORPAY_BASE}/settlements/{settlement_id}/recon/combined",
+            auth=auth,
+            params={"count": RECON_PAGE_SIZE, "skip": skip},
+            timeout=30,
+        )
+
+        if resp.status_code == 404:
+            # Recon endpoint not enabled on this Razorpay account
+            frappe.logger().warning(
+                f"sync_settlements: recon/combined not available for {settlement_id} (404)"
+            )
+            break
+
+        if not resp.ok:
+            frappe.logger().error(
+                f"sync_settlements: recon error for {settlement_id}: "
+                f"{resp.status_code} {resp.text[:200]}"
+            )
+            break
+
+        batch = resp.json().get("items") or []
+        items.extend(batch)
+
+        if len(batch) < RECON_PAGE_SIZE:
+            break
+        skip += RECON_PAGE_SIZE
+
+    return items

--- a/slcm/slcm/doctype/foundations_for_a_legal_education/foundations_for_a_legal_education.py
+++ b/slcm/slcm/doctype/foundations_for_a_legal_education/foundations_for_a_legal_education.py
@@ -55,6 +55,9 @@ class FoundationsforaLegalEducation(Document):
 		try:
 			payment_log = frappe.new_doc("FLE Payment Log")
 			payment_log.reference_no = self.name
+			# fetch_from does not fire on programmatic insert — set explicitly
+			payment_log.full_name = self.candidate_name or ""
+			payment_log.email = self.email_address or ""
 			payment_log.payment_status = exact_status
 			payment_log.paid_amount = paid_amount_logged
 			payment_log.transaction_id = razorpay_payment_id

--- a/slcm/slcm/report/fle_razorpay_settlement_report/fle_razorpay_settlement_report.js
+++ b/slcm/slcm/report/fle_razorpay_settlement_report/fle_razorpay_settlement_report.js
@@ -1,5 +1,6 @@
 frappe.query_reports["FLE Razorpay Settlement Report"] = {
 	onload: function (report) {
+		// ── Export buttons ────────────────────────────────────────────────────
 		report.page.add_inner_button(__("Download Excel"), function () {
 			frappe.query_report.export_report("Excel");
 		}, __("Export"));
@@ -7,6 +8,102 @@ frappe.query_reports["FLE Razorpay Settlement Report"] = {
 		report.page.add_inner_button(__("Download CSV"), function () {
 			frappe.query_report.export_report("CSV");
 		}, __("Export"));
+
+		// ── Diagnose Missing Matches button ──────────────────────────────────
+		report.page.add_inner_button(__("Diagnose Missing Names"), function () {
+			frappe.call({
+				method: "slcm.api.sync_settlements.diagnose_missing_matches",
+				freeze: true,
+				freeze_message: __("Analysing settlement vs FLE Payment Log..."),
+				callback: function (r) {
+					if (!r.message) return;
+					var d = r.message;
+					var recon_status = d.recon_api_available
+						? '<span style="color:green">✔ Available</span>'
+						: '<span style="color:red">✘ Not enabled on this Razorpay account (404)</span>';
+					var html = `
+						<table class="table table-bordered table-sm" style="font-size:13px">
+							<tr><td><b>Recon/Combined API</b></td><td>${recon_status}</td></tr>
+							<tr><td><b>Total settlements</b></td><td>${d.total_settlements}</td></tr>
+							<tr><td><b>Razorpay payment IDs (pay_xxx) in settlements</b></td><td>${d.total_razorpay_payment_ids}</td></tr>
+							<tr><td><b>FLE Payment Log total records</b></td><td>${d.total_fle_payment_log_records}</td></tr>
+							<tr><td><b>FLE Payment Log rows with NULL transaction_id</b></td><td>${d.fle_rows_with_null_tid}</td></tr>
+							<tr style="background:#d4edda"><td><b>Matched (settlement ID found in FLE log)</b></td><td>${d.matched_with_fle_log}</td></tr>
+							<tr style="background:#f8d7da"><td><b>Unmatched (no FLE log entry at all)</b></td><td>${d.unmatched_no_fle_log}</td></tr>
+							<tr style="background:#fff3cd"><td><b>Matched but contact name is blank</b></td><td>${d.matched_but_blank_name}</td></tr>
+						</table>
+						${d.sample_unmatched_ids && d.sample_unmatched_ids.length ? "<b>Sample unmatched pay_xxx IDs (no FLE log):</b><br>" + d.sample_unmatched_ids.join("<br>") : ""}
+						${d.sample_blank_name_ids && d.sample_blank_name_ids.length ? "<br><b>Sample IDs matched but name blank:</b><br>" + d.sample_blank_name_ids.join("<br>") : ""}
+					`;
+					frappe.msgprint({ title: __("Diagnosis Result"), message: html, indicator: "blue", wide: true });
+				},
+			});
+		}, __("Actions"));
+
+		// ── Backfill Contact Names button ─────────────────────────────────────
+		// Fixes existing FLE Payment Log rows where full_name is blank
+		report.page.add_inner_button(__("Fix Contact Names"), function () {
+			frappe.call({
+				method: "slcm.api.sync_settlements.backfill_contact_names",
+				freeze: true,
+				freeze_message: __("Backfilling contact names from FLE records..."),
+				callback: function (r) {
+					if (r.message) {
+						frappe.msgprint({ title: __("Done"), message: r.message, indicator: "green" });
+						frappe.query_report.refresh();
+					}
+				},
+			});
+		}, __("Actions"));
+
+		// ── Sync Settlements button ───────────────────────────────────────────
+		// Triggers a full re-sync of past Razorpay settlements into FLE Payment Log
+		report.page.add_inner_button(__("Sync Settlements"), function () {
+			frappe.confirm(
+				__("This will sync all past Razorpay settlements into the FLE Payment Log. This may take a minute. Continue?"),
+				function () {
+					frappe.show_progress(__("Syncing Settlements"), 0, 100, __("Calling Razorpay API..."));
+					frappe.call({
+						method: "slcm.api.sync_settlements.run_sync",
+						freeze: true,
+						freeze_message: __("Syncing settlements from Razorpay..."),
+						callback: function (r) {
+							frappe.hide_progress();
+							if (r.message) {
+								frappe.msgprint({
+									title: __("Sync Complete"),
+									message: r.message,
+									indicator: "green",
+								});
+								frappe.query_report.refresh();
+							}
+						},
+						error: function (r) {
+							frappe.hide_progress();
+							frappe.msgprint({
+								title: __("Sync Failed"),
+								message: __("Could not sync settlements. Check the error log for details."),
+								indicator: "red",
+							});
+						},
+					});
+				}
+			);
+		}, __("Actions"));
+	},
+
+	before_submit: function (filters) {
+		// Guard: from_date must not be after to_date
+		var from = filters.from_date;
+		var to   = filters.to_date;
+		if (from && to && frappe.datetime.str_to_obj(from) > frappe.datetime.str_to_obj(to)) {
+			frappe.msgprint({
+				title: __("Invalid Date Range"),
+				message: __("From Date cannot be after To Date. Please correct your filters."),
+				indicator: "red",
+			});
+			return false;
+		}
 	},
 
 	filters: [
@@ -16,6 +113,17 @@ frappe.query_reports["FLE Razorpay Settlement Report"] = {
 			fieldtype: "Date",
 			default: frappe.datetime.month_start(),
 			reqd: 0,
+			on_change: function () {
+				var from = frappe.query_report.get_filter_value("from_date");
+				var to   = frappe.query_report.get_filter_value("to_date");
+				if (from && to && frappe.datetime.str_to_obj(from) > frappe.datetime.str_to_obj(to)) {
+					frappe.msgprint({
+						title: __("Invalid Date Range"),
+						message: __("From Date cannot be after To Date."),
+						indicator: "orange",
+					});
+				}
+			},
 		},
 		{
 			fieldname: "to_date",
@@ -23,11 +131,23 @@ frappe.query_reports["FLE Razorpay Settlement Report"] = {
 			fieldtype: "Date",
 			default: frappe.datetime.month_end(),
 			reqd: 0,
+			on_change: function () {
+				var from = frappe.query_report.get_filter_value("from_date");
+				var to   = frappe.query_report.get_filter_value("to_date");
+				if (from && to && frappe.datetime.str_to_obj(from) > frappe.datetime.str_to_obj(to)) {
+					frappe.msgprint({
+						title: __("Invalid Date Range"),
+						message: __("To Date cannot be before From Date."),
+						indicator: "orange",
+					});
+				}
+			},
 		},
 		{
 			fieldname: "status",
 			label: __("Status"),
 			fieldtype: "Select",
+			// Values sent to Python — normalised to lowercase in Python for comparison
 			options: "\nSettled\nPending",
 			reqd: 0,
 		},

--- a/slcm/slcm/report/fle_razorpay_settlement_report/fle_razorpay_settlement_report.json
+++ b/slcm/slcm/report/fle_razorpay_settlement_report/fle_razorpay_settlement_report.json
@@ -10,7 +10,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letter_head": null,
- "modified": "2026-05-08 00:00:00.000000",
+ "modified": "2026-05-21 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "SLCM",
  "name": "FLE Razorpay Settlement Report",
@@ -22,7 +22,13 @@
  "roles": [
   {
    "role": "System Manager"
+  },
+  {
+   "role": "Accounts Manager"
+  },
+  {
+   "role": "Accounts User"
   }
  ],
- "timeout": 0
+ "timeout": 300
 }

--- a/slcm/slcm/report/fle_razorpay_settlement_report/fle_razorpay_settlement_report.py
+++ b/slcm/slcm/report/fle_razorpay_settlement_report/fle_razorpay_settlement_report.py
@@ -1,19 +1,18 @@
 """
 FLE Razorpay Settlement Report
 
-Data model: one row per recon item (individual payment/refund within a settlement).
+Fetches live data directly from the Razorpay API on every run.
 
-API calls made:
-  GET /v1/settlements                    – paginated list of settlements (metadata)
-  GET /v1/settlements/recon/combined     – ALL payment items across settlements
+API calls:
+  GET /v1/settlements                 – paginated settlement list with metadata
+  GET /v1/settlements/recon/combined  – per-payment breakdown (requires year+month params)
 
-Enrichment: local FLE Payment Log is joined by transaction_id (= Razorpay
-payment ID = recon entity_id) to pull contact name, student ID, and
-payment method stored by the webhook handler.
+Local enrichment: joins FLE Payment Log by transaction_id to get student name,
+student ID, and payment method stored by the webhook handler.
 
-Authentication order:
-  1. Razorpay Settings DocType  (api_key / api_secret)
-  2. site_config.json / frappe.conf  (razorpay_api_key / razorpay_api_secret)
+Auth priority:
+  1. Razorpay Settings DocType (api_key / api_secret)
+  2. site_config.json (razorpay_api_key / razorpay_api_secret)
 """
 
 import json
@@ -28,13 +27,13 @@ from frappe import _
 # ---------------------------------------------------------------------------
 
 RAZORPAY_BASE   = "https://api.razorpay.com/v1"
-PAGE_SIZE       = 100           # max per page for settlements list
-RECON_PAGE_SIZE = 1000          # max per page for recon/combined
+PAGE_SIZE       = 100
+RECON_PAGE_SIZE = 1000
 DEFAULT_ACCOUNT = "Foundation for Legal Education"
 DEFAULT_COURSE  = "Foundations for a Legal Education"
 
 # ---------------------------------------------------------------------------
-# Report entry point
+# Entry point
 # ---------------------------------------------------------------------------
 
 
@@ -64,28 +63,28 @@ def execute(filters=None):
 
 def _get_columns():
     return [
-        {"label": _("Settlement ID"),         "fieldname": "settlement_id",      "fieldtype": "Data",     "width": 190},
-        {"label": _("Transaction ID"),        "fieldname": "transaction_id",     "fieldtype": "Data",     "width": 190},
-        {"label": _("Entity ID"),             "fieldname": "entity_id",          "fieldtype": "Data",     "width": 190},
-        {"label": _("Currency"),              "fieldname": "currency",           "fieldtype": "Data",     "width":  70},
-        {"label": _("Amount (₹)"),            "fieldname": "amount",             "fieldtype": "Currency", "width": 120},
-        {"label": _("Fees (₹)"),              "fieldname": "fees",               "fieldtype": "Currency", "width": 110},
-        {"label": _("Tax (₹)"),               "fieldname": "tax",                "fieldtype": "Currency", "width": 100},
-        {"label": _("Net Amount (₹)"),        "fieldname": "net_amount",         "fieldtype": "Currency", "width": 130},
-        {"label": _("Payment Method"),        "fieldname": "payment_method",     "fieldtype": "Data",     "width": 130},
-        {"label": _("Payment Notes"),         "fieldname": "payment_notes",      "fieldtype": "Data",     "width": 210},
-        {"label": _("Account"),               "fieldname": "account",            "fieldtype": "Data",     "width": 230},
-        {"label": _("Contact Name"),          "fieldname": "contact_name",       "fieldtype": "Data",     "width": 160},
-        {"label": _("Debit"),                 "fieldname": "debit",              "fieldtype": "Currency", "width": 120},
-        {"label": _("Credit"),                "fieldname": "credit",             "fieldtype": "Currency", "width": 120},
-        {"label": _("Course"),                "fieldname": "course",             "fieldtype": "Data",     "width": 230},
-        {"label": _("Student ID"),            "fieldname": "student_id",         "fieldtype": "Data",     "width": 140},
-        {"label": _("Status"),                "fieldname": "status",             "fieldtype": "Data",     "width": 110},
-        {"label": _("UTR"),                   "fieldname": "utr",                "fieldtype": "Data",     "width": 170},
-        {"label": _("Entity Created At"),     "fieldname": "entity_created_at",  "fieldtype": "Datetime", "width": 160},
-        {"label": _("Payment Captured At"),   "fieldname": "payment_captured_at","fieldtype": "Datetime", "width": 165},
-        {"label": _("Settlement Created"),    "fieldname": "created_date",       "fieldtype": "Datetime", "width": 155},
-        {"label": _("Settlement Processed"),  "fieldname": "processed_date",     "fieldtype": "Datetime", "width": 165},
+        {"label": _("Settlement ID"),        "fieldname": "settlement_id",      "fieldtype": "Data",     "width": 190},
+        {"label": _("Transaction ID"),       "fieldname": "transaction_id",     "fieldtype": "Data",     "width": 190},
+        {"label": _("Entity ID"),            "fieldname": "entity_id",          "fieldtype": "Data",     "width": 190},
+        {"label": _("Currency"),             "fieldname": "currency",           "fieldtype": "Data",     "width":  70},
+        {"label": _("Amount (₹)"),           "fieldname": "amount",             "fieldtype": "Currency", "width": 120},
+        {"label": _("Fees (₹)"),             "fieldname": "fees",               "fieldtype": "Currency", "width": 110},
+        {"label": _("Tax (₹)"),              "fieldname": "tax",                "fieldtype": "Currency", "width": 100},
+        {"label": _("Net Amount (₹)"),       "fieldname": "net_amount",         "fieldtype": "Currency", "width": 130},
+        {"label": _("Payment Method"),       "fieldname": "payment_method",     "fieldtype": "Data",     "width": 130},
+        {"label": _("Payment Notes"),        "fieldname": "payment_notes",      "fieldtype": "Data",     "width": 210},
+        {"label": _("Account"),              "fieldname": "account",            "fieldtype": "Data",     "width": 230},
+        {"label": _("Contact Name"),         "fieldname": "contact_name",       "fieldtype": "Data",     "width": 160},
+        {"label": _("Debit"),                "fieldname": "debit",              "fieldtype": "Currency", "width": 120},
+        {"label": _("Credit"),               "fieldname": "credit",             "fieldtype": "Currency", "width": 120},
+        {"label": _("Course"),               "fieldname": "course",             "fieldtype": "Data",     "width": 230},
+        {"label": _("Student ID"),           "fieldname": "student_id",         "fieldtype": "Data",     "width": 140},
+        {"label": _("Status"),               "fieldname": "status",             "fieldtype": "Data",     "width": 110},
+        {"label": _("UTR"),                  "fieldname": "utr",                "fieldtype": "Data",     "width": 170},
+        {"label": _("Entity Created At"),    "fieldname": "entity_created_at",  "fieldtype": "Datetime", "width": 160},
+        {"label": _("Payment Captured At"),  "fieldname": "payment_captured_at","fieldtype": "Datetime", "width": 165},
+        {"label": _("Settlement Created"),   "fieldname": "created_date",       "fieldtype": "Datetime", "width": 155},
+        {"label": _("Settlement Processed"), "fieldname": "processed_date",     "fieldtype": "Datetime", "width": 165},
     ]
 
 
@@ -95,63 +94,74 @@ def _get_columns():
 
 
 def _get_data(filters):
+    # --- Validate dates -------------------------------------------------------
+    from_date = filters.get("from_date")
+    to_date   = filters.get("to_date")
+
+    if from_date and to_date:
+        try:
+            fd = datetime.strptime(str(from_date), "%Y-%m-%d")
+            td = datetime.strptime(str(to_date),   "%Y-%m-%d")
+            if fd > td:
+                frappe.throw(
+                    _("From Date ({0}) cannot be after To Date ({1}). Please fix your date filters.").format(
+                        from_date, to_date
+                    ),
+                    title=_("Invalid Date Range"),
+                )
+        except ValueError:
+            pass
+
     api_key, api_secret = _get_credentials()
     auth = (api_key, api_secret)
 
-    from_ts, to_ts = _date_filters_to_unix(filters)
-    status_filter  = (filters.get("status") or "").strip().lower()
+    from_ts, to_ts = _date_filters_to_unix(from_date, to_date)
+    # Status filter: JS sends "Settled" / "Pending" — normalise to lowercase for comparison
+    status_filter = (filters.get("status") or "").strip().lower()
 
-    # ── Step 1: fetch settlement list (for metadata) ──────────────────────────
+    # Step 1: fetch settlement list (metadata + UTR)
     settlements = _fetch_all_settlements(auth, from_ts, to_ts)
 
     if not settlements:
         frappe.msgprint(
-            _("No settlements found from Razorpay for the selected filters."),
+            _("No settlements found from Razorpay for the selected date range."),
             indicator="blue",
             alert=True,
         )
         return [], {}
 
-    # Build settlement lookup: settlement_id → settlement dict
-    # Also build utr → settlement_id map (for linking recon items)
     setl_by_id  = {s["id"]: s for s in settlements if s.get("id")}
     setl_by_utr = {s["utr"]: s["id"] for s in settlements if s.get("utr")}
 
-    # ── Step 2: fetch recon items for our settlements from recon/combined ───────
+    # Step 2: fetch per-payment recon breakdown
     recon_items = _fetch_combined_recon(
         auth,
         settlement_ids=list(setl_by_id.keys()),
-        from_date=filters.get("from_date"),
-        to_date=filters.get("to_date"),
+        from_date=from_date,
+        to_date=to_date,
         settlements=settlements,
     )
 
-    # Build local enrichment map: razorpay payment_id → {contact, student, method}
+    # Step 3: enrich from local FLE Payment Log
     local_map = _build_local_map()
 
     data = []
     total_amount = total_fees = total_tax = total_net = 0.0
-
-    # ── Step 3: build rows from recon items ────────────────────────────────────
     matched_settlement_ids = set()
 
     for item in recon_items:
-        # Resolve parent settlement
         item_sid = (
             item.get("settlement_id")
             or setl_by_utr.get(item.get("settlement_utr", ""))
             or ""
         )
-        s = setl_by_id.get(item_sid) or {}
+        s   = setl_by_id.get(item_sid) or {}
+        utr = item.get("settlement_utr") or s.get("utr") or ""
 
-        utr    = item.get("settlement_utr") or s.get("utr") or ""
+        # A recon item is settled when it has a UTR (linked to a processed settlement)
         status = "settled" if utr else "pending"
-
         if status_filter and status != status_filter:
             continue
-
-        created_date   = _unix_to_datetime(s.get("created_at"))
-        processed_date = _unix_to_datetime(s.get("settlement_time") or s.get("created_at"))
 
         entity_id      = item.get("entity_id") or item.get("payment_id") or ""
         transaction_id = item.get("payment_id") or entity_id
@@ -161,28 +171,28 @@ def _get_data(filters):
         item_tax    = _paise_to_rupees(item.get("tax",    0))
         net_amount  = round(item_amount - item_fees - item_tax, 2)
 
-        item_debit  = _paise_to_rupees(item.get("debit",  0))
-        item_credit = _paise_to_rupees(item.get("credit", 0))
-        debit  = item_debit  if item_debit  else item_amount
-        credit = item_credit if item_credit else net_amount
+        r_debit  = _paise_to_rupees(item.get("debit",  0))
+        r_credit = _paise_to_rupees(item.get("credit", 0))
+        debit  = r_debit  if r_debit  else item_amount
+        credit = r_credit if r_credit else net_amount
 
         entity_created_at   = _unix_to_datetime(item.get("created_at"))
         payment_captured_at = _unix_to_datetime(item.get("posted_at") or item.get("settled_at"))
 
-        recon_description = item.get("description") or item.get("order_receipt") or ""
-
+        notes_from_api = item.get("description") or item.get("order_receipt") or ""
         local          = local_map.get(transaction_id) or local_map.get(entity_id) or {}
         contact_name   = local.get("contact_name",   "")
         student_id     = local.get("student_id",     "")
         payment_method = local.get("payment_method", "")
-        local_notes    = local.get("payment_notes",  "")
-        payment_notes  = recon_description or local_notes
+        payment_notes  = notes_from_api or local.get("payment_notes", "")
+
+        created_date   = _unix_to_datetime(s.get("created_at"))
+        processed_date = _unix_to_datetime(s.get("settlement_time") or s.get("created_at"))
 
         total_amount += item_amount
         total_fees   += item_fees
         total_tax    += item_tax
         total_net    += net_amount
-
         matched_settlement_ids.add(item_sid)
 
         data.append(_make_row(
@@ -199,7 +209,7 @@ def _get_data(filters):
             created_date=created_date, processed_date=processed_date,
         ))
 
-    # ── Step 4: fallback rows for settlements with no recon items ─────────────
+    # Step 4: fallback rows for settlements that had no recon items
     for s in settlements:
         sid = s.get("id", "")
         if sid in matched_settlement_ids:
@@ -207,7 +217,6 @@ def _get_data(filters):
 
         utr    = s.get("utr") or ""
         status = "settled" if utr else "pending"
-
         if status_filter and status != status_filter:
             continue
 
@@ -223,8 +232,7 @@ def _get_data(filters):
 
         data.append(_make_row(
             settlement_id=sid,
-            transaction_id="",
-            entity_id="",
+            transaction_id="", entity_id="",
             amount=s_amount, fees=s_fees, tax=s_tax, net_amount=s_net,
             debit=s_amount, credit=s_net,
             payment_method="", payment_notes="",
@@ -326,23 +334,29 @@ def _fetch_combined_recon(auth, settlement_ids, from_date=None, to_date=None, se
     """
     Fetch payment-level items from GET /v1/settlements/recon/combined.
 
-    This endpoint requires `year` and `month` query params (no from/to timestamps).
-    We iterate over each year-month in the requested date range, paginate each
-    month's results, and keep only items whose settlement_id is in our set.
-
-    Falls back gracefully (returns []) when the endpoint returns 404 (feature
-    not enabled) or when no date range can be determined.
+    - Requires year + month query params (Razorpay limitation — no from/to timestamps).
+    - Iterates each year-month in the requested date range.
+    - Keeps only items whose settlement_id is in our target set.
+    - Items with settlement_id=None are included when they belong to a settlement
+      that exists in our set (matched via settlement_utr).
+    - Returns [] gracefully when the endpoint is not enabled (404).
     """
     if not settlement_ids:
         return []
 
-    target_ids = set(settlement_ids)
+    target_ids  = set(settlement_ids)
     year_months = _resolve_year_months(from_date, to_date, settlements)
 
     if not year_months:
         return []
 
-    # Deduplicate across months: same entity_id can appear in multiple months
+    # Build UTR → settlement_id map so we can match items that lack settlement_id
+    utr_to_sid = {}
+    if settlements:
+        for s in settlements:
+            if s.get("utr") and s.get("id"):
+                utr_to_sid[s["utr"]] = s["id"]
+
     seen_entity_ids = set()
     all_items       = []
 
@@ -357,7 +371,8 @@ def _fetch_combined_recon(auth, settlement_ids, from_date=None, to_date=None, se
             )
 
             if resp.status_code == 404:
-                return all_items   # feature not enabled; return what we have
+                # Feature not enabled on this Razorpay account — return what we have
+                return all_items
 
             _raise_for_razorpay_error(resp)
 
@@ -365,16 +380,27 @@ def _fetch_combined_recon(auth, settlement_ids, from_date=None, to_date=None, se
             page_items = payload.get("items", [])
 
             for item in page_items:
-                # Only keep items that belong to our settlements AND are settled
-                if item.get("settlement_id") not in target_ids:
+                sid = item.get("settlement_id")
+
+                # Try to resolve settlement_id from UTR when it's missing
+                if not sid:
+                    utr = item.get("settlement_utr") or ""
+                    sid = utr_to_sid.get(utr)
+
+                # Only keep items belonging to our settlements
+                if sid not in target_ids:
                     continue
-                if not item.get("settled"):
-                    continue   # exclude unsettled / on-hold items
+
+                # Attach resolved settlement_id back to the item for downstream use
+                if not item.get("settlement_id") and sid:
+                    item["settlement_id"] = sid
+
                 eid = item.get("entity_id") or item.get("payment_id") or ""
                 if eid and eid in seen_entity_ids:
-                    continue   # skip duplicate across month queries
+                    continue
                 if eid:
                     seen_entity_ids.add(eid)
+
                 all_items.append(item)
 
             if len(page_items) < RECON_PAGE_SIZE:
@@ -389,7 +415,7 @@ def _resolve_year_months(from_date, to_date, settlements):
     Return a sorted list of (year, month) tuples covering the requested range.
 
     Priority:
-      1. from_date / to_date filter strings  ("YYYY-MM-DD")
+      1. from_date / to_date filter strings ("YYYY-MM-DD")
       2. Derived from the settlement created_at timestamps (fallback)
     """
     year_months = set()
@@ -398,18 +424,25 @@ def _resolve_year_months(from_date, to_date, settlements):
         try:
             start = datetime.strptime(str(from_date), "%Y-%m-%d")
             end   = datetime.strptime(str(to_date),   "%Y-%m-%d")
-            y, m  = start.year, start.month
-            while (y, m) <= (end.year, end.month):
-                year_months.add((y, m))
-                m += 1
-                if m > 12:
-                    m = 1
-                    y += 1
+            # Ensure we never iterate backwards
+            if start <= end:
+                y, m = start.year, start.month
+                while (y, m) <= (end.year, end.month):
+                    year_months.add((y, m))
+                    m += 1
+                    if m > 12:
+                        m = 1
+                        y += 1
+        except ValueError:
+            pass
+    elif from_date:
+        try:
+            d = datetime.strptime(str(from_date), "%Y-%m-%d")
+            year_months.add((d.year, d.month))
         except ValueError:
             pass
 
     if not year_months and settlements:
-        # Fall back: derive from settlement created_at timestamps
         for s in settlements:
             ts = s.get("created_at")
             if ts:
@@ -425,25 +458,38 @@ def _resolve_year_months(from_date, to_date, settlements):
 def _raise_for_razorpay_error(resp):
     if resp.status_code == 401:
         frappe.throw(
-            _("Razorpay authentication failed. Check API Key and Secret in Razorpay Settings."),
+            _(
+                "Razorpay authentication failed. "
+                "Check your API Key and Secret in <b>Razorpay Settings</b>."
+            ),
             title=_("Authentication Error"),
         )
     if not resp.ok:
+        try:
+            err_body = resp.json().get("error", {}).get("description", resp.text[:300])
+        except Exception:
+            err_body = resp.text[:300]
         frappe.throw(
-            _("Razorpay API error {0}: {1}").format(resp.status_code, resp.text[:300]),
+            _("Razorpay API error {0}: {1}").format(resp.status_code, err_body),
             title=_("API Error"),
         )
 
 
 # ---------------------------------------------------------------------------
-# Local enrichment
+# Local enrichment from FLE Payment Log
 # ---------------------------------------------------------------------------
 
 
 def _build_local_map():
     """
-    Return dict keyed by Razorpay payment_id from FLE Payment Log rows.
-    Values carry contact / student / payment-method info stored by the webhook.
+    Return a dict keyed by Razorpay pay_xxx ID → {contact_name, student_id, payment_method, payment_notes}
+    built from ALL FLE Payment Log rows.
+
+    Key resolution order per row:
+      1. transaction_id field (set directly on insert when available)
+      2. razorpay_payment_id extracted from gateway_response JSON
+         (Integration Request data format: {"razorpay_payment_id": "pay_xxx", ...})
+      3. id inside gateway_response payload.payment.entity (webhook format)
     """
     if not frappe.db.table_exists("FLE Payment Log"):
         return {}
@@ -451,23 +497,30 @@ def _build_local_map():
     rows = frappe.db.sql(
         """
         SELECT
-            fpl.transaction_id           AS payment_id,
-            fpl.full_name                AS contact_name,
-            fpl.reference_no             AS student_id,
-            fpl.gateway_response         AS gateway_response,
-            fpl.account_number_or_upi_id AS upi_or_account
-        FROM `tabFLE Payment Log` fpl
-        WHERE fpl.transaction_id IS NOT NULL
-          AND fpl.transaction_id != ''
+            transaction_id           AS transaction_id,
+            full_name                AS contact_name,
+            reference_no             AS student_id,
+            gateway_response,
+            account_number_or_upi_id AS upi_or_account
+        FROM `tabFLE Payment Log`
         """,
         as_dict=True,
     )
 
     local_map = {}
     for row in rows:
-        pid = row.payment_id
+        # Resolve the Razorpay pay_xxx ID
+        pid = (row.transaction_id or "").strip()
+
+        if not pid or not pid.startswith("pay_"):
+            # transaction_id is blank or a bank RRN — extract pay_xxx from gateway_response
+            pid = _extract_razorpay_pid(row.gateway_response)
+
+        if not pid:
+            continue
         if pid in local_map:
             continue
+
         method, notes = _parse_gateway_response(row.gateway_response, row.upi_or_account)
         local_map[pid] = {
             "contact_name":   row.contact_name or "",
@@ -476,6 +529,25 @@ def _build_local_map():
             "payment_notes":  notes,
         }
     return local_map
+
+
+def _extract_razorpay_pid(gateway_response):
+    """Extract a Razorpay pay_xxx ID from the gateway_response JSON blob."""
+    if not gateway_response:
+        return ""
+    try:
+        data = json.loads(gateway_response)
+        # Format 1: Integration Request data {"razorpay_payment_id": "pay_xxx"}
+        pid = data.get("razorpay_payment_id") or ""
+        if pid and pid.startswith("pay_"):
+            return pid
+        # Format 2: webhook payload {"payload": {"payment": {"entity": {"id": "pay_xxx"}}}}
+        pid = data.get("payload", {}).get("payment", {}).get("entity", {}).get("id") or ""
+        if pid and pid.startswith("pay_"):
+            return pid
+    except Exception:
+        pass
+    return ""
 
 
 def _parse_gateway_response(gateway_response, upi_or_account):
@@ -487,14 +559,14 @@ def _parse_gateway_response(gateway_response, upi_or_account):
 
     try:
         resp   = json.loads(gateway_response)
+        # Support both webhook-style payload and raw Razorpay payment objects
         entity = resp.get("payload", {}).get("payment", {}).get("entity", resp)
-
         method = entity.get("method") or ""
-        parts  = []
-        for key in ("bank", "wallet", "vpa", "description"):
-            val = entity.get(key) or ""
-            if val:
-                parts.append(str(val))
+        parts  = [
+            str(entity[k])
+            for k in ("bank", "wallet", "vpa", "description")
+            if entity.get(k)
+        ]
         if parts:
             notes = " | ".join(parts)
     except Exception:
@@ -509,7 +581,7 @@ def _parse_gateway_response(gateway_response, upi_or_account):
 
 
 def _get_credentials():
-    """Priority: Razorpay Settings DocType → site_config / frappe.conf"""
+    """Priority: Razorpay Settings DocType → site_config.json / frappe.conf"""
     try:
         settings = frappe.get_doc("Razorpay Settings")
         key    = settings.api_key
@@ -559,25 +631,19 @@ def _unix_to_datetime(ts):
     if not ts:
         return None
     try:
-        return datetime.fromtimestamp(int(ts), tz=timezone.utc).strftime(
-            "%Y-%m-%d %H:%M:%S"
-        )
+        return datetime.fromtimestamp(int(ts), tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     except (TypeError, ValueError, OSError):
         return None
 
 
-def _date_filters_to_unix(filters):
+def _date_filters_to_unix(from_date, to_date):
     from_ts = to_ts = None
-    from_date = filters.get("from_date")
-    to_date   = filters.get("to_date")
-
     if from_date:
         try:
             dt = datetime.strptime(str(from_date), "%Y-%m-%d").replace(tzinfo=timezone.utc)
             from_ts = int(dt.timestamp())
         except ValueError:
             pass
-
     if to_date:
         try:
             dt = datetime.strptime(str(to_date), "%Y-%m-%d").replace(
@@ -586,7 +652,6 @@ def _date_filters_to_unix(filters):
             to_ts = int(dt.timestamp())
         except ValueError:
             pass
-
     return from_ts, to_ts
 
 
@@ -598,13 +663,11 @@ def _date_filters_to_unix(filters):
 def _build_summary_message(summary):
     if not summary.get("count"):
         return None
-
-    lines = [
+    return "<br>".join([
         "<b>Summary</b>",
         f"Total Payments    : {summary['count']}",
         f"Total Amount (₹)  : {summary['total_amount']:,.2f}",
         f"Total Fees (₹)    : {summary['total_fees']:,.2f}",
         f"Total Tax (₹)     : {summary['total_tax']:,.2f}",
         f"Net Total (₹)     : {summary['total_net']:,.2f}",
-    ]
-    return "<br>".join(lines)
+    ])


### PR DESCRIPTION
1. slcm/api/fix_reports.py (New file) Purpose: One-time fix for the cloud site's "background report" error.

When someone accidentally enables "Prepared Report" on the cloud Frappe UI, the report breaks with the JS crash (report_end_time TypeError). This file:

Resets prepared_report = 0 in the database
Deletes stale "Prepared Report" documents that cause the crash Run once on cloud: bench execute slcm.api.fix_reports.reset_prepared_report_flags
2. slcm/api/sync_settlements.py (Modified) Purpose: Manual tools to sync and diagnose settlement data. Contains 3 functions:

Function	What it does
run_sync()	Fetches all settlements from Razorpay API and writes settlement_id, UTR, gateway_fees, net_settled into matching FLE Payment Log records backfill_contact_names()	Fixes FLE Payment Log rows where full_name is blank by copying from the linked FLE document diagnose_missing_matches()	Compares Razorpay settlement pay_xxx IDs against FLE Payment Log — shows exactly how many match, how many are missing, and why
3. slcm/slcm/doctype/founda.../foundations_for_a_legal_education.py (Modified) Purpose: Fixes full_name and email not being saved when a new FLE Payment Log is created on payment.

Frappe's fetch_from only works in the browser — not in server-side insert(). Added 2 lines to explicitly set:

payment_log.full_name = self.candidate_name
payment_log.email     = self.email_address
All future payments will now have the student name correctly saved.

4. slcm/report/fle_razorpay.../fle_razorpay_settlement_report.js (Modified) Purpose: The report's frontend filter and button file. Added:

Actions → Diagnose Missing Names — runs the diagnosis and shows a popup table Actions → Fix Contact Names — runs the backfill for blank names Actions → Sync Settlements — triggers full settlement sync from Razorpay Date validation — warns immediately if From Date is after To Date (prevents the swapped-date bug seen in the cloud URL)
5. slcm/report/fle_razorpay.../fle_razorpay_settlement_report.json (Modified) Purpose: The report's configuration stored in the database. Changed:

"prepared_report": 0 — ensures it never runs as a background report "timeout": 300 — gives 5 minutes for the live Razorpay API calls to complete on cloud "modified": "2026-05-21" — bumped so Frappe's fixture sync picks up the changes on cloud Added Accounts Manager and Accounts User roles so finance team can access it
6. slcm/report/fle_razorpay.../fle_razorpay_settlement_report.py (Modified) Purpose: The core report logic that fetches live data from Razorpay. Fixed:

Date validation — throws a clear error if From Date > To Date instead of silently returning wrong data _build_local_map() — previously only joined on transaction_id field; now also extracts pay_xxx from gateway_response JSON as fallback (fixes the Contact Name being blank) _extract_razorpay_pid() — new helper that reads pay_xxx from two gateway response formats (Integration Request format and Webhook format) Recon null settlement_id — items where settlement_id is null are now resolved via settlement_utr instead of being silently dropped