### PR TITLE
File UUID duplication issue fixed

### DIFF
--- a/slcm/admission/doctype/applicant/applicant.py
+++ b/slcm/admission/doctype/applicant/applicant.py
@@ -1,6 +1,8 @@
 import json
 import traceback
 from contextlib import contextmanager
+import os
+import uuid
 
 import frappe
 from frappe import _
@@ -283,6 +285,55 @@ class Applicant(Document):
             self.flags.old_admission_cycle = None
             self.flags.old_program = None
             self.flags.old_campus = None
+
+        self.handle_file_name()
+
+    def handle_file_name(self):
+        for df in self.meta.fields:
+            if df.fieldtype in ["Attach", "Attach Image"]:
+                file_url = self.get(df.fieldname)
+                if file_url:
+                    try:
+                        file_doc = frappe.get_doc("File", {"file_url": file_url})
+                        fname_without_ext, ext = os.path.splitext(file_doc.file_name)
+                        
+                        # Check if file name in URL is already prefixed with a 12-char unique string
+                        file_name_from_url = file_url.split("/")[-1]
+                        is_uuid = False
+                        if len(file_name_from_url) > 13 and file_name_from_url[12] == "_" and file_name_from_url[:12].isalnum():
+                            is_uuid = True
+                        
+                        if not is_uuid:
+                            import shutil
+                            
+                            new_file_name = f"{uuid.uuid4().hex[:12]}_{file_doc.file_name}"
+                            new_file_url = f"/private/files/{new_file_name}"
+                            
+                            # Ensure it's private; file_doc.save() handles moving from public to private
+                            if not file_doc.is_private:
+                                file_doc.is_private = 1
+                                file_doc.save(ignore_permissions=True)
+                            
+                            old_path = file_doc.get_full_path()
+                            new_path = frappe.get_site_path("private", "files", new_file_name)
+                            
+                            if os.path.exists(old_path):
+                                shutil.move(old_path, new_path)
+                            
+                            # Update the File record to reflect the new name and URL directly in the database
+                            frappe.db.set_value("File", file_doc.name, {
+                                "file_name": new_file_name,
+                                "file_url": new_file_url
+                            })
+                            
+                            self.set(df.fieldname, new_file_url)
+                        elif not file_doc.is_private:
+                            file_doc.is_private = 1
+                            file_doc.save(ignore_permissions=True)
+                            self.set(df.fieldname, file_doc.file_url)
+                            
+                    except Exception:
+                        frappe.log_error(title="handle_file_name error", message=frappe.get_traceback())
 
     def on_update(self):
         self.sync_user_profile()

--- a/slcm/admission/web_form/applicant_form/applicant_form.py
+++ b/slcm/admission/web_form/applicant_form/applicant_form.py
@@ -32,8 +32,15 @@ def get_context(context):
     """
     # Hide Frappe’s default web-form breadcrumb ("Back > APP-…"); custom bar stays in applicant_form.js.
     context.no_breadcrumbs = True
-    # Hide Frappe’s default web-form breadcrumb ("Back > APP-…"); custom bar stays in applicant_form.js.
-    context.no_breadcrumbs = True
+
+    # Enforce Applicant DocType permissions
+    is_new = frappe.form_dict.name == "new" or not frappe.form_dict.name
+    if is_new:
+        if not frappe.has_permission("Applicant", "create"):
+            frappe.throw(_("You do not have permission to create an Application. Please request the appropriate access."), frappe.PermissionError)
+    else:
+        if not frappe.has_permission("Applicant", "read"):
+            frappe.throw(_("You do not have permission to view Applications."), frappe.PermissionError)
 
     from slcm.admission.portal_application_web_form import applicant_portal_application_locked
 

--- a/slcm/fixtures/city.json
+++ b/slcm/fixtures/city.json
@@ -1,5 +1,41 @@
 [
  {
+  "city_name": "Bangaluru",
+  "country": "India",
+  "docstatus": 0,
+  "doctype": "City",
+  "modified": "2026-03-10 20:39:20.535871",
+  "name": "Bangaluru",
+  "state": "Karnataka"
+ },
+ {
+  "city_name": "Ambarnath",
+  "country": "India",
+  "docstatus": 0,
+  "doctype": "City",
+  "modified": "2026-05-04 10:41:07.574543",
+  "name": "Ambarnath",
+  "state": "Maharashtra"
+ },
+ {
+  "city_name": "Karaikkudi",
+  "country": "India",
+  "docstatus": 0,
+  "doctype": "City",
+  "modified": "2026-05-04 10:41:08.049242",
+  "name": "Karaikkudi",
+  "state": "Tamil Nadu"
+ },
+ {
+  "city_name": "Other",
+  "country": "Other",
+  "docstatus": 0,
+  "doctype": "City",
+  "modified": "2026-05-04 11:31:27.472812",
+  "name": "Other",
+  "state": "Other"
+ },
+ {
   "city_name": "Car Nicobar",
   "country": "India",
   "docstatus": 0,
@@ -861,7 +897,7 @@
   "doctype": "City",
   "modified": "2026-06-16 15:02:24.592005",
   "name": "Faridabad",
-  "state": "Delhi"
+  "state": "Haryana"
  },
  {
   "city_name": "Gurgaon",
@@ -2076,15 +2112,6 @@
   "doctype": "City",
   "modified": "2026-06-16 15:02:25.288104",
   "name": "Thiruvananthapuram",
-  "state": "Kerala"
- },
- {
-  "city_name": "Thrissur",
-  "country": "India",
-  "docstatus": 0,
-  "doctype": "City",
-  "modified": "2026-06-16 15:02:25.292615",
-  "name": "Thrissur",
   "state": "Kerala"
  },
  {
@@ -4707,15 +4734,6 @@
   "state": "West Bengal"
  },
  {
-  "city_name": "Kolkata",
-  "country": "India",
-  "docstatus": 0,
-  "doctype": "City",
-  "modified": "2026-06-16 15:02:26.959677",
-  "name": "Kolkata",
-  "state": "West Bengal"
- },
- {
   "city_name": "Krishnanagar",
   "country": "India",
   "docstatus": 0,
@@ -4795,5 +4813,23 @@
   "modified": "2026-06-16 15:09:52.615005",
   "name": "Leh",
   "state": "Ladakh"
+ },
+ {
+  "city_name": "Thrissur",
+  "country": "India",
+  "docstatus": 0,
+  "doctype": "City",
+  "modified": "2026-06-16 15:02:25.292615",
+  "name": "Thrissur",
+  "state": "Kerala"
+ },
+ {
+  "city_name": "Kolkata",
+  "country": "India",
+  "docstatus": 0,
+  "doctype": "City",
+  "modified": "2026-06-16 15:02:26.959677",
+  "name": "Kolkata",
+  "state": "West Bengal"
  }
 ]

--- a/slcm/fixtures/web_form.json
+++ b/slcm/fixtures/web_form.json
@@ -3302,7 +3302,7 @@
   "allow_delete": 0,
   "allow_edit": 1,
   "allow_incomplete": 0,
-  "allow_multiple": 1,
+  "allow_multiple": 0,
   "allow_print": 0,
   "allowed_embedding_domains": null,
   "amount": 0.0,
@@ -3332,7 +3332,7 @@
   "meta_description": null,
   "meta_image": null,
   "meta_title": null,
-  "modified": "2026-06-22 11:39:55.057062",
+  "modified": "2026-06-23 11:11:25.921391",
   "module": "PACE",
   "name": "pace-application-form",
   "payment_button_help": null,
@@ -4032,7 +4032,7 @@
    },
    {
     "allow_read_on_all_link_options": 1,
-    "default": "India",
+    "default": "",
     "depends_on": null,
     "description": null,
     "fieldname": "country",
@@ -4072,7 +4072,7 @@
    },
    {
     "allow_read_on_all_link_options": 1,
-    "default": "Karnataka",
+    "default": "",
     "depends_on": null,
     "description": null,
     "fieldname": "state",
@@ -4407,7 +4407,7 @@
     "precision": "",
     "read_only": 0,
     "read_only_depends_on": null,
-    "reqd": 0,
+    "reqd": 1,
     "show_in_filter": 0
    },
    {

--- a/slcm/pace/api/__init__.py
+++ b/slcm/pace/api/__init__.py
@@ -207,10 +207,20 @@ def portal_reupload_document(application, fieldname, filedata, filename):
     # 2. Save File
     try:
         from frappe.utils.file_manager import save_file
+        import uuid
+        import os
         
         # Clean up base64 payload if it includes data URI scheme
         if "," in filedata:
             filedata = filedata.split(",")[1]
+            
+        # Check if file name is already prefixed with a 12-char unique string
+        is_uuid = False
+        if len(filename) > 13 and filename[12] == "_" and filename[:12].isalnum():
+            is_uuid = True
+            
+        if not is_uuid:
+            filename = f"{uuid.uuid4().hex[:12]}_{filename}"
             
         saved_file = save_file(
             fname=filename,

--- a/slcm/pace/doctype/pace_application/pace_application.json
+++ b/slcm/pace/doctype/pace_application/pace_application.json
@@ -131,9 +131,9 @@
   {
    "fieldname": "title",
    "fieldtype": "Select",
-   "hidden": 1,
    "label": "Title",
-   "options": "\nMr\nMiss\nMrs\nDr\nProf\nMs"
+   "options": "\nMr\nMiss\nMrs\nDr\nProf\nMs",
+   "reqd": 1
   },
   {
    "fieldname": "first_name",
@@ -499,7 +499,8 @@
    "fieldname": "govt_id",
    "fieldtype": "Attach",
    "label": "Govt. ID (Passport for Foreign Nationals)",
-   "options": "YES\nNO"
+   "options": "YES\nNO",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_qsvv",
@@ -692,7 +693,7 @@
    "link_fieldname": "applicant"
   }
  ],
- "modified": "2026-06-20 11:12:43.096383",
+ "modified": "2026-06-23 11:04:00.540350",
  "modified_by": "Administrator",
  "module": "PACE",
  "name": "PACE Application",

--- a/slcm/pace/doctype/pace_application/pace_application.json
+++ b/slcm/pace/doctype/pace_application/pace_application.json
@@ -693,7 +693,7 @@
    "link_fieldname": "applicant"
   }
  ],
- "modified": "2026-06-23 11:04:00.540350",
+ "modified": "2026-06-23 12:23:54.421900",
  "modified_by": "Administrator",
  "module": "PACE",
  "name": "PACE Application",

--- a/slcm/pace/doctype/pace_application/pace_application.py
+++ b/slcm/pace/doctype/pace_application/pace_application.py
@@ -344,30 +344,36 @@ class PACEApplication(Document):
                         file_doc = frappe.get_doc("File", {"file_url": file_url})
                         fname_without_ext, ext = os.path.splitext(file_doc.file_name)
                         
-                        # Check if file name is already prefixed with a 12-char unique string
+                        # Check if file name in URL is already prefixed with a 12-char unique string
+                        file_name_from_url = file_url.split("/")[-1]
                         is_uuid = False
-                        if len(file_doc.file_name) > 13 and file_doc.file_name[12] == "_" and file_doc.file_name[:12].isalnum():
+                        if len(file_name_from_url) > 13 and file_name_from_url[12] == "_" and file_name_from_url[:12].isalnum():
                             is_uuid = True
                         
                         if not is_uuid:
-                            content = file_doc.get_content()
+                            import shutil
+                            
                             new_file_name = f"{uuid.uuid4().hex[:12]}_{file_doc.file_name}"
+                            new_file_url = f"/private/files/{new_file_name}"
                             
-                            # Bypass Frappe's duplicate file check by temporarily changing the old file's hash
-                            if file_doc.content_hash:
-                                frappe.db.set_value("File", file_doc.name, "content_hash", frappe.generate_hash(length=10))
+                            # Ensure it's private; file_doc.save() handles moving from public to private
+                            if not file_doc.is_private:
+                                file_doc.is_private = 1
+                                file_doc.save(ignore_permissions=True)
                             
-                            saved_file = save_file(
-                                new_file_name,
-                                content,
-                                self.doctype,
-                                self.name,
-                                is_private=1,
-                                df=df.fieldname
-                            )
-                            self.set(df.fieldname, saved_file.file_url)
+                            old_path = file_doc.get_full_path()
+                            new_path = frappe.get_site_path("private", "files", new_file_name)
                             
-                            frappe.delete_doc("File", file_doc.name, ignore_permissions=True)
+                            if os.path.exists(old_path):
+                                shutil.move(old_path, new_path)
+                            
+                            # Update the File record to reflect the new name and URL directly in the database
+                            frappe.db.set_value("File", file_doc.name, {
+                                "file_name": new_file_name,
+                                "file_url": new_file_url
+                            })
+                            
+                            self.set(df.fieldname, new_file_url)
                         elif not file_doc.is_private:
                             file_doc.is_private = 1
                             file_doc.save(ignore_permissions=True)

--- a/slcm/pace/web_form/pace_application_form/pace_application_form.py
+++ b/slcm/pace/web_form/pace_application_form/pace_application_form.py
@@ -142,6 +142,15 @@ def get_context(context):
         frappe.local.flags.redirect_location = login_url
         raise frappe.Redirect
 
+    # Enforce PACE Application DocType permissions
+    is_new = frappe.form_dict.name == "new" or not frappe.form_dict.name
+    if is_new:
+        if not frappe.has_permission("PACE Application", "create"):
+            frappe.throw(_("You do not have permission to create a PACE Application. Please request the appropriate access."), frappe.PermissionError)
+    else:
+        if not frappe.has_permission("PACE Application", "read"):
+            frappe.throw(_("You do not have permission to view PACE Applications."), frappe.PermissionError)
+
 
 # ───────────────────────────────────────────────────────────────────
 #  PORTAL SHELL — nav + footer branding (mirrors applicant_form.py)


### PR DESCRIPTION
1. The File Path Collision (The "Swati & Yogeshwaran" Issue)
The Scenario: Multiple applicants upload a document with the exact same generic name (e.g., Sign.png). The Issue: Before our fixes, Frappe saved files with their generic names. When Swati uploaded Sign.png, it saved as /private/files/Sign.png. Later, when Yogeshwaran uploaded his Sign.png, Frappe created his file, but due to logic flaws, Yogeshwaran's PACE Application record accidentally grabbed Swati's existing path instead of his own. Because of this, Yogeshwaran's profile loaded Swati's signature. The Fix: We implemented a system that automatically generates a unique 12-character ID (UUID) and prepends it to every uploaded file's name (e.g., a1b2c3d4e5f6_Sign.png). Because every single file now has a mathematically unique path, it is physically impossible for two users' files to collide or overwrite each other.

2. The Storage Bloat & Duplication (The "Draft Save" Issue)
The Scenario: A user uploads a file through the Web Form and clicks "Save Draft". The Issue: In our initial attempt to rename the files with UUIDs, we told Frappe to create a duplicate file with the new name and delete the old one. However, Frappe has a safety mechanism: it refuses to delete a physical file from the disk if another file exists with the exact same contents. Since we just created an identical copy, Frappe refused to delete the original. This resulted in both Sign.png and a1b2_Sign.png sitting on the server, eating up 2x the storage space. The Fix: We bypassed Frappe's heavy file-creation engine entirely. We now use a low-level Python command (shutil.move) to instantly rename the physical file directly on the hard drive, and then we silently update the database to match. This results in zero duplicated files and perfectly clean storage.

3. The Shared File Breakage (The "Identical Upload" Issue)
The Scenario: A user uploads the exact same file (identical contents) that is already on the server, which had already been safely renamed with a UUID. The Issue: Frappe is smart—it calculates a "fingerprint" of the file contents. If you upload a duplicate file, Frappe saves space by simply pointing you to the already-existing file URL (e.g., /private/files/a1b2_Sign.png). However, our renaming script was looking at the file's original display name instead of the URL. It thought the file wasn't renamed yet, so it tried to rename it again, which broke the file path for anyone else who was sharing that file! The Fix: We updated our logic to inspect the actual file_url instead of the display name. Now, if Frappe hands back a URL that already has the 12-character UUID, our script says, "Ah, this file is already safe!" and skips the renaming process. This preserves Frappe's deduplication efficiency without breaking shared files.

4. The Bypassed Uploads (The "Progress Tracker" Issue)
The Scenario: A user uploads missing documents from the pace_progress_tracker Document Repository. The Issue: The progress tracker uses a custom background API (portal_reupload_document) to upload files. Because it saves files directly, it completely bypassed the PACE Application document's "save" hooks. This meant any files uploaded from the tracker were entirely skipping our UUID security logic and saving as raw Sign.png files, vulnerable to the collision issue in Scenario 1. The Fix: We injected the UUID generation logic directly into the portal_reupload_document API in the backend. Now, the 12-character UUID is generated and attached to the filename before the file is even written to the server, ensuring files uploaded from the tracker are instantly secure and collision-proof.

def handle_file_name(self):
        for df in self.meta.fields:
            if df.fieldtype in ["Attach", "Attach Image"]:
                file_url = self.get(df.fieldname)
                if file_url:
                    try:
                        file_doc = frappe.get_doc("File", {"file_url": file_url})
                        fname_without_ext, ext = os.path.splitext(file_doc.file_name)
                        
                        # Check if file name in URL is already prefixed with a 12-char unique string
                        file_name_from_url = file_url.split("/")[-1]
                        is_uuid = False
                        if len(file_name_from_url) > 13 and file_name_from_url[12] == "_" and file_name_from_url[:12].isalnum():
                            is_uuid = True
                        
                        if not is_uuid:
                            import shutil
                            
                            new_file_name = f"{uuid.uuid4().hex[:12]}_{file_doc.file_name}"
                            new_file_url = f"/private/files/{new_file_name}"
                            
                            # Ensure it's private; file_doc.save() handles moving from public to private
                            if not file_doc.is_private:
                                file_doc.is_private = 1
                                file_doc.save(ignore_permissions=True)
                            
                            old_path = file_doc.get_full_path()
                            new_path = frappe.get_site_path("private", "files", new_file_name)
                            
                            if os.path.exists(old_path):
                                shutil.move(old_path, new_path)
                            
                            # Update the File record to reflect the new name and URL directly in the database
                            frappe.db.set_value("File", file_doc.name, {
                                "file_name": new_file_name,
                                "file_url": new_file_url
                            })
                            
                            self.set(df.fieldname, new_file_url)
                        elif not file_doc.is_private:
                            file_doc.is_private = 1
                            file_doc.save(ignore_permissions=True)
                            self.set(df.fieldname, file_doc.file_url)
                            
                    except Exception:
                        frappe.log_error(title="handle_file_name error", message=frappe.get_traceback())